### PR TITLE
Fix the name of the psychic pacifier ability

### DIFF
--- a/1.3/Defs/ThingDefs_Items/Items_Artifacts.xml
+++ b/1.3/Defs/ThingDefs_Items/Items_Artifacts.xml
@@ -50,7 +50,7 @@
     <verbs>
       <li>
         <verbClass>VFEI.Verb_CastHumanEffect</verbClass>
-        <label>psychic animal tamer</label>
+        <label>psychic pacifier</label>
         <hasStandardCommand>true</hasStandardCommand>
         <targetable>true</targetable>
         <onlyManualCast>True</onlyManualCast>


### PR DESCRIPTION
When a pawn carrying a psychic pacifier is drafted, the item's ability name would show "Psychic Animal Tamer" instead of "Psychic Pacifier".